### PR TITLE
feat: add maplebridge.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [makojs.dev](https://makojs.dev/llms.txt)
 - [manifest.ly (full)](https://manifest.ly/llms-full.txt)
 - [manifest.ly](https://manifest.ly/llms.txt)
+- [maplebridge.io](https://maplebridge.io/llms.txt)
 - [martijnvanderdoes.com](https://martijnvanderdoes.com/llms.txt)
 - [mastra.ai (full)](https://mastra.ai/llms-full.txt)
 - [mastra.ai](https://mastra.ai/llms.txt)


### PR DESCRIPTION
Adds maplebridge.io to the list.

AI-powered B2B matching platform for Canada-China trade. Free for buyers.

llms.txt: https://maplebridge.io/llms.txt