### PR TITLE
Add dailygoal.fit (fitness + nutrition tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [convex.dev](https://convex.dev/llms.txt)
 - [cookbook_ao.g8way.io](https://cookbook_ao.g8way.io/llms.txt)
 - [cv.ryoppippi.com (full)](https://cv.ryoppippi.com/llms-full.txt)
+- [dailygoal.fit (full)](https://www.dailygoal.fit/llms-full.txt)
+- [dailygoal.fit](https://www.dailygoal.fit/llms.txt)
 - [daisyui.com](https://daisyui.com/llms.txt)
 - [daisyui.tailwind.org.cn](https://daisyui.tailwind.org.cn/llms.txt)
 - [datacamp.com](https://datacamp.com/llms.txt)


### PR DESCRIPTION
Adds DailyGoal's llms.txt and llms-full.txt to the index.

- llms.txt: https://www.dailygoal.fit/llms.txt
- llms-full.txt: https://www.dailygoal.fit/llms-full.txt

DailyGoal is a health, fitness, and nutrition tracking app (iOS + web). Entries inserted in alphabetical order between `cv.ryoppippi.com` and `daisyui.com`, following the same `(full)`-before-base ordering used elsewhere in the list.