### PR TITLE
Add aidevboard.com, 8bitconcepts.com, nothumansearch.ai llms.txt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This list contains an index of llms.txt files hosted on various websites. Attach them to your llm with [MCP-llms-txt](https://github.com/SecretiveShell/MCP-llms-txt)
 
+- [8bitconcepts.com](https://8bitconcepts.com/llms.txt)
 - [abonnement-iptv-france.fr](https://abonnement-iptv-france.fr/llms.txt)
 - [absoluteinternship.com](https://absoluteinternship.com/llms.txt)
 - [adsbravo.com](https://adsbravo.com/llms.txt)
+- [aidevboard.com](https://aidevboard.com/llms.txt)
 - [ai-interviewer.micro1.ai](https://ai-interviewer.micro1.ai/llms.txt)
 - [akademicevre.com](https://akademicevre.com/llms.txt)
 - [alexop.dev](https://alexop.dev/llms.txt)
@@ -512,6 +514,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [neuronup.com](https://neuronup.com/llms.txt)
 - [nexech.com](https://nexech.com/llms.txt)
 - [norwegian4x4.com](https://norwegian4x4.com/llms.txt)
+- [nothumansearch.ai](https://nothumansearch.ai/llms.txt)
+- [nothumansearch.ai (full)](https://nothumansearch.ai/llms-full.txt)
 - [novilabs.com](https://novilabs.com/llms.txt)
 - [onagents.org](https://onagents.org/llms.txt)
 - [onevcat.com](https://onevcat.com/llms.txt)


### PR DESCRIPTION
Three new llms.txt entries inserted alphabetically:

- `8bitconcepts.com/llms.txt` — enterprise AI research papers
- `aidevboard.com/llms.txt` — AI/ML engineering jobs directory
- `nothumansearch.ai/llms.txt` + `nothumansearch.ai/llms-full.txt` — agent-first search engine (also exposes an MCP server at `/mcp` and a REST API at `/api/v1/search`)

All three are active, canonical llms.txt files. Useful as seed data for the MCP-llms-txt tool.