### PR TITLE
Add universalcommerceprotocol.blog (FR/EN bilingual editorial hub on UCP & agentic commerce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [turbo.build](https://turbo.build/llms.txt)
 - [twittershots.com (full)](https://twittershots.com/llms-full.txt)
 - [unhead.unjs.io](https://unhead.unjs.io/llms.txt)
+- [universalcommerceprotocol.blog (EN)](https://universalcommerceprotocol.blog/llms-en.txt)
+- [universalcommerceprotocol.blog](https://universalcommerceprotocol.blog/llms.txt)
 - [upstash.com (full)](https://upstash.com/docs/llms-full.txt)
 - [upstash.com](https://upstash.com/docs/llms.txt)
 - [use-fireproof.com (full)](https://use-fireproof.com/llms-full.txt)


### PR DESCRIPTION
## What this adds

Two entries for `universalcommerceprotocol.blog`, a bilingual (FR/EN) editorial site covering the Universal Commerce Protocol (Google's open standard for agentic commerce, launched at NRF Jan 2026):

- `universalcommerceprotocol.blog` → https://universalcommerceprotocol.blog/llms.txt
- `universalcommerceprotocol.blog (EN)` → https://universalcommerceprotocol.blog/llms-en.txt

## Why it fits

The site publishes structured `llms.txt` and `llms-en.txt` files following the standard spec, with full article summaries, pillar page descriptions, and editorial context. The EN variant is specifically designed to expose French-only articles to English-speaking AI crawlers.

Both files are live and well-formed.