### PR TITLE
Add vertoai.it

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [uxpatterns.dev (full)](https://uxpatterns.dev/en/llms-full.txt)
 - [uxpatterns.dev](https://uxpatterns.dev/en/llms.txt)
 - [valdhealth.com](https://valdhealth.com/llms.txt)
+- [vertoai.it (full)](https://vertoai.it/llms-full.txt)
+- [vertoai.it](https://vertoai.it/llms.txt)
 - [vidovi.ch](https://vidovi.ch/llms.txt)
 - [viem.sh (full)](https://viem.sh/llms-full.txt)
 - [viem.sh](https://viem.sh/llms.txt)


### PR DESCRIPTION
Adds [vertoai.it](https://vertoai.it/) — AI concierge for short-term rental property managers (WhatsApp guest automation, multilingual, GDPR-compliant, made in Italy).

Both `llms.txt` and `llms-full.txt` are live and verified HTTP 200:
- https://vertoai.it/llms.txt
- https://vertoai.it/llms-full.txt

Inserted in alphabetical order between `valdhealth.com` and `vidovi.ch`.