### PR TITLE
Add brewpage.app — llms.txt and llms-full.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [blog.zithara.com](https://blog.zithara.com/llms.txt)
 - [boehs.org](https://boehs.org/llms.txt)
 - [booqable.com](https://booqable.com/llms.txt)
+- [brewpage.app (full)](https://brewpage.app/llms-full.txt)
+- [brewpage.app](https://brewpage.app/llms.txt)
 - [buckybodycenter.com](https://buckybodycenter.com/llms.txt)
 - [builtwith.com](https://builtwith.com/llms.txt)
 - [bun.sh](https://bun.sh/llms.txt)


### PR DESCRIPTION
### Site

[brewpage.app](https://brewpage.app) — free hosting for HTML, Markdown, JSON, key-value pairs, files, and multi-file sites. REST API + AI-agent friendly.

### Files

- https://brewpage.app/llms.txt (short index)
- https://brewpage.app/llms-full.txt (full expansion, 569 lines)

Both served with `Content-Type: text/plain; charset=utf-8`, status 200, follow the llms.txt convention (headings, links, descriptions). Content covers: what BrewPage is, REST API surface, resource limits, MCP server, OpenAPI link, example publishing flows.

### Placement

Alphabetical, after `booqable.com`, before `buckybodycenter.com`. Two entries (`(full)` and short form) matching the existing pattern (e.g. `ast-grep.github.io`, `axiom.co`, `chakra-ui.com`).

### Checklist

- [x] Both URLs return 200.
- [x] Content-Type is `text/plain`.
- [x] Content follows llms.txt convention.
- [x] Alphabetical placement.