### PR TITLE
Add dualmark.dev to the llms.txt index

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [documentation.blitzllama.com](https://documentation.blitzllama.com/llms.txt)
 - [dotenvx.com (full)](https://dotenvx.com/llms-full.txt)
 - [dotenvx.com](https://dotenvx.com/llms.txt)
+- [dualmark.dev](https://dualmark.dev/llms.txt)
 - [dub.co (full)](https://dub.co/docs/llms-full.txt)
 - [dub.co](https://dub.co/docs/llms.txt)
 - [duckdb.org](https://duckdb.org/duckdb-docs.md)

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -342,6 +342,7 @@
     "https://docspring.com/llms.txt",
     "https://documentation.blitzllama.com/llms.txt",
     "https://dotenvx.com/llms.txt",
+    "https://dualmark.dev/llms.txt",
     "https://dub.co/docs/llms.txt",
     "https://elevenlabs.io/docs/llms.txt",
     "https://emailgic.com/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -407,6 +407,7 @@
     "https://documentation.blitzllama.com/llms.txt",
     "https://dotenvx.com/llms-full.txt",
     "https://dotenvx.com/llms.txt",
+    "https://dualmark.dev/llms.txt",
     "https://dub.co/docs/llms-full.txt",
     "https://dub.co/docs/llms.txt",
     "https://duckdb.org/duckdb-docs.md",


### PR DESCRIPTION
Adds [dualmark.dev/llms.txt](https://dualmark.dev/llms.txt) to the index.

**Site:** [dualmark.dev](https://dualmark.dev) — open-source AEO infrastructure (markdown twins via HTTP content negotiation + llms.txt generation + AI-bot UA detection). The site itself dogfoods the spec it implements.

Updated all three files to keep them in sync:
- `README.md` — alphabetically between dotenvx and dub.co
- `json/urls.json` — same insertion point
- `json/llms-txt.json` — same insertion point

Validated both JSON files parse cleanly. Happy to adjust placement or wording if needed.