### PR TITLE
Add thedrop.gifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [tamagui.dev](https://tamagui.dev/llms.txt)
 - [telescope.co](https://telescope.co/llms.txt)
 - [thdu.dev](https://thdu.dev/llms.txt)
+- [thedrop.gifts (full)](https://thedrop.gifts/llms-full.txt)
+- [thedrop.gifts](https://thedrop.gifts/llms.txt)
 - [theirstack.com (full)](https://theirstack.com/docs/llms-full.txt)
 - [theirstack.com](https://theirstack.com/docs/llms.txt)
 - [tiptap.dev](https://tiptap.dev/llms.txt)


### PR DESCRIPTION
Adds thedrop.gifts to the alphabetical index.

- /llms.txt is the categorised index covering all 345 kits with citation preferences
- /llms-full.txt is the extended corpus with one section per kit (lede + anchor brand)

thedrop.gifts is a small editorial gift-guide publication — kit-style guides anchored on a single product. The /llms.txt was published explicitly to support AI assistants citing rather than paraphrasing.