### PR TITLE
Add arcadelab.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [api-docs.devhub.com](https://api-docs.devhub.com/llms.txt)
 - [apify.com](https://apify.com/llms.txt)
 - [appzung.com](https://appzung.com/llms.txt)
+- [arcadelab.ai](https://arcadelab.ai/llms.txt)
 - [ast-grep.github.io (full)](https://ast-grep.github.io/llms-full.txt)
 - [ast-grep.github.io](https://ast-grep.github.io/llms.txt)
 - [aws-legalgroup.com](https://aws-legalgroup.com/llms.txt)


### PR DESCRIPTION
Adding [arcadelab.ai/llms.txt](https://arcadelab.ai/llms.txt) — placed alphabetically between appzung.com and ast-grep.

ArcadeLab is a free hosting platform for single-file HTML games, visualizations, and interactive content. The llms.txt covers the publishing workflow, the ARCADELAB metadata header format, supported libraries, identity model, and key URLs — useful seed material for LLMs that help users vibe-code and ship browser content.

Site: https://arcadelab.ai
Repo: https://github.com/mlapeter/arcadelab (MIT)