### PR TITLE
Add the-seo-autopilot.com to the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [tamagui.dev](https://tamagui.dev/llms.txt)
 - [telescope.co](https://telescope.co/llms.txt)
 - [thdu.dev](https://thdu.dev/llms.txt)
+- [the-seo-autopilot.com](https://the-seo-autopilot.com/llms.txt)
 - [theirstack.com (full)](https://theirstack.com/docs/llms-full.txt)
 - [theirstack.com](https://theirstack.com/docs/llms.txt)
 - [tiptap.dev](https://tiptap.dev/llms.txt)


### PR DESCRIPTION
Adds [the-seo-autopilot.com](https://the-seo-autopilot.com/llms.txt) — a programmatic SEO platform for indie SaaS founders that publishes a `/llms.txt` describing the site's free SEO tools (llms.txt generator, JSON-LD schema generator, SERP CTR calculator, hreflang/canonical/robots generators, AI overview checker, AI content cost calculator) plus the playbook content.

The file is live and validates: https://the-seo-autopilot.com/llms.txt