### PR TITLE
Add ai-first-scraper and ai-first-search

### DIFF
--- a/json/urls.json
+++ b/json/urls.json
@@ -2,6 +2,8 @@
     "https://abonnement-iptv-france.fr/llms.txt",
     "https://absoluteinternship.com/llms.txt",
     "https://adsbravo.com/llms.txt",
+    "https://ai-first-scraper.onrender.com/llms.txt",
+    "https://ai-first-search.onrender.com/llms.txt",
     "https://ai-interviewer.micro1.ai/llms.txt",
     "https://akademicevre.com/llms.txt",
     "https://alexop.dev/llms.txt",


### PR DESCRIPTION
Adding two llms.txt URLs from a pair of related open-source APIs designed for LLM agent consumption:

- \`https://ai-first-scraper.onrender.com/llms.txt\` — ad-free Markdown extraction API
- \`https://ai-first-search.onrender.com/llms.txt\` — search-engine-backed multi-URL Markdown extraction API

Inserted alphabetically in \`json/urls.json\`. Both endpoints are live and stable.