### PR TITLE
Add unlocksaas.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [turbo.build](https://turbo.build/llms.txt)
 - [twittershots.com (full)](https://twittershots.com/llms-full.txt)
 - [unhead.unjs.io](https://unhead.unjs.io/llms.txt)
+- [unlocksaas.com (full)](https://unlocksaas.com/llms-full.txt)
+- [unlocksaas.com](https://unlocksaas.com/llms.txt)
 - [upstash.com (full)](https://upstash.com/docs/llms-full.txt)
 - [upstash.com](https://upstash.com/docs/llms.txt)
 - [use-fireproof.com (full)](https://use-fireproof.com/llms-full.txt)


### PR DESCRIPTION
Adds unlocksaas.com and its full corpus mirror.

- https://unlocksaas.com/llms.txt — 14 KB curated index
- https://unlocksaas.com/llms-full.txt — 963 KB concatenated corpus

Both surfaces ship `Last verified` / `Next review` ISO dates so retrievers can downweight stale citations. Honest empty state for `Earned media` until real mentions publish.

Alphabetical placement: between `unhead.unjs.io` and `upstash.com`.