### PR TITLE
Add ultiplace.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [use-fireproof.com (full)](https://use-fireproof.com/llms-full.txt)
 - [use-fireproof.com](https://use-fireproof.com/llms.txt)
 - [useagents.io](https://useagents.io/llms.txt)
+- [ultiplace.com (full)](https://www.ultiplace.com/llms-full.txt)
+- [ultiplace.com](https://www.ultiplace.com/llms.txt)
 - [uxpatterns.dev (full)](https://uxpatterns.dev/en/llms-full.txt)
 - [uxpatterns.dev](https://uxpatterns.dev/en/llms.txt)
 - [valdhealth.com](https://valdhealth.com/llms.txt)


### PR DESCRIPTION
Adds ultiplace.com (French B2B virtual & physical trade-show platform) to the list. Both `/llms.txt` and `/llms-full.txt` are served from the apex domain.

Made with [Cursor](https://cursor.com)