### PR TITLE
Add agentgrade.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [abonnement-iptv-france.fr](https://abonnement-iptv-france.fr/llms.txt)
 - [absoluteinternship.com](https://absoluteinternship.com/llms.txt)
 - [adsbravo.com](https://adsbravo.com/llms.txt)
+- [agentgrade.com (full)](https://agentgrade.com/llms-full.txt)
+- [agentgrade.com](https://agentgrade.com/llms.txt)
 - [ai-interviewer.micro1.ai](https://ai-interviewer.micro1.ai/llms.txt)
 - [akademicevre.com](https://akademicevre.com/llms.txt)
 - [alexop.dev](https://alexop.dev/llms.txt)


### PR DESCRIPTION
Adds agentgrade.com to the list. Both the short and full versions are served:

- https://agentgrade.com/llms.txt
- https://agentgrade.com/llms-full.txt

AgentGrade is a scanner that grades websites on AI agent readiness — among other things, it scans for the presence and validity of llms.txt on the sites it checks, so eating our own dog food felt necessary. Placed alphabetically.
