### PR TITLE
Add happyaging.com to the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [gr-docs.aporia.com](https://gr-docs.aporia.com/llms.txt)
 - [handbook.exemplar.dev (full)](https://handbook.exemplar.dev/llms-full.txt)
 - [handbook.exemplar.dev](https://handbook.exemplar.dev/llms.txt)
+- [happyaging.com (full)](https://happyaging.com/pages/ai-index)
+- [happyaging.com](https://happyaging.com/llms.txt)
 - [herd.garden (full)](https://herd.garden/llms-full.txt)
 - [herd.garden](https://herd.garden/llms.txt)
 - [himalayas.app](https://himalayas.app/llms.txt)


### PR DESCRIPTION
## What

Adds Happy Aging to the directory — two entries (short + full).

```diff
+ - [happyaging.com (full)](https://happyaging.com/pages/ai-index)
+ - [happyaging.com](https://happyaging.com/llms.txt)
```

## About Happy Aging

US-based longevity wellness brand for women 40+ ([Wikidata Q139720291](https://www.wikidata.org/wiki/Q139720291)).

Content is medically reviewed by Dr. Daniel Yadegar, MD, FACC, RPVI (Harvard Medical School / Atria Institute, NPI 1538363213).

## Why two entries

Shopify's platform-level LlmsTxtController intercepts requests to `/llms.txt` and serves an auto-generated short version (~2KB) that the merchant cannot override. To provide the full 130KB rich knowledge base — covering 790+ medically-reviewed articles on NAD+/NMN science, perimenopause, hormonal health, GLP-1 nutrition, sleep, and longevity — we host the full content at `/pages/ai-index`.

Both URLs are valid llms.txt content:
- `/llms.txt` — short brand + product overview (2,132 bytes)
- `/pages/ai-index` — full curated knowledge base (130,177 bytes), Wikidata Q139720291 referenced, full article index

Listed both in case AI clients only follow the standard path.