### PR TITLE
Add RenoBrief link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [www.zycus.com](https://www.zycus.com/llms.txt)
 - [wxt.dev](https://wxt.dev/knowledge/docs.txt)
 - [zbrain.ai](https://zbrain.ai/llms.txt)
+- [RenoBrief](https://renobrief.com/llms.txt)
 
 ## Directories
 


### PR DESCRIPTION
Add [https://renobrief.com/] to the llms.txt list

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

The JSON files are generated automatically after merge.
