### PR TITLE
Add Longevity World Cup

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [llmstxtmanager.com](https://llmstxtmanager.com/llms.txt)
 - [lmstudio.ai (full)](https://lmstudio.ai/llms-full.txt)
 - [lmstudio.ai](https://lmstudio.ai/llms.txt)
+- [longevityworldcup.com (full)](https://longevityworldcup.com/llms-full.txt)
+- [longevityworldcup.com](https://longevityworldcup.com/llms.txt)
 - [loops.so (full)](https://loops.so/docs/llms-full.txt)
 - [loops.so](https://loops.so/docs/llms.txt)
 - [lotsofcsvs.com](https://lotsofcsvs.com/llms.txt)

--- a/json/llms-full.json
+++ b/json/llms-full.json
@@ -87,6 +87,7 @@
     "https://llm.rememberizer.ai/llms-full.txt",
     "https://llm.skydeck.ai/llms-full.txt",
     "https://lmstudio.ai/llms-full.txt",
+    "https://longevityworldcup.com/llms-full.txt",
     "https://loops.so/docs/llms-full.txt",
     "https://manifest.ly/llms-full.txt",
     "https://medscanada.com/llms-full.txt",

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -392,6 +392,7 @@
     "https://llmstxt.org/llms.txt",
     "https://llmstxtmanager.com/llms.txt",
     "https://lmstudio.ai/llms.txt",
+    "https://longevityworldcup.com/llms.txt",
     "https://loops.so/docs/llms.txt",
     "https://lotsofcsvs.com/llms.txt",
     "https://lugg.com/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -480,6 +480,8 @@
     "https://llmstxtmanager.com/llms.txt",
     "https://lmstudio.ai/llms-full.txt",
     "https://lmstudio.ai/llms.txt",
+    "https://longevityworldcup.com/llms-full.txt",
+    "https://longevityworldcup.com/llms.txt",
     "https://loops.so/docs/llms-full.txt",
     "https://loops.so/docs/llms.txt",
     "https://lotsofcsvs.com/llms.txt",


### PR DESCRIPTION
Adds Longevity World Cup's published llms.txt and llms-full.txt files to the index.\n\nBoth files are publicly reachable:\n- https://longevityworldcup.com/llms.txt\n- https://longevityworldcup.com/llms-full.txt