### PR TITLE
feat: add gruzdevv.ru llms.txt and llms-full.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [global-chat.io](https://global-chat.io/llms.txt)
 - [gokcetransfer.com](https://gokcetransfer.com/llms.txt)
 - [gr-docs.aporia.com](https://gr-docs.aporia.com/llms.txt)
+- [gruzdevv.ru (full)](https://gruzdevv.ru/llms-full.txt)
+- [gruzdevv.ru](https://gruzdevv.ru/llms.txt)
 - [handbook.exemplar.dev (full)](https://handbook.exemplar.dev/llms-full.txt)
 - [handbook.exemplar.dev](https://handbook.exemplar.dev/llms.txt)
 - [handledtax.com](https://handledtax.com/llms.txt)


### PR DESCRIPTION
## Add gruzdevv.ru

Adds [gruzdevv.ru](https://gruzdevv.ru) — a SaaS analytics and review platform for the Russian market.

- **llms.txt**: https://gruzdevv.ru/llms.txt
- **llms-full.txt**: https://gruzdevv.ru/llms-full.txt

The platform aggregates SaaS services, internet banks, CPA networks, ad networks, payment aggregators, and online schools with expert reviews and user ratings.