### PR TITLE
Add PubFi llms entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [prisma.io](https://prisma.io/docs/llms.txt)
 - [prisma.io](https://prisma.io/llms.txt)
 - [promptessor.com (full)](https://promptessor.com/llms-full.txt)
+- [pubfi.ai (full)](https://pubfi.ai/llms-full.txt)
+- [pubfi.ai](https://pubfi.ai/llms.txt)
 - [python.langchain.com](https://python.langchain.com/llms.txt)
 - [rainbowkit.com (full)](https://rainbowkit.com/llms-full.txt)
 - [rainbowkit.com](https://rainbowkit.com/llms.txt)

--- a/json/llms-full.json
+++ b/json/llms-full.json
@@ -104,6 +104,7 @@
     "https://prisma.io/docs/llms-full.txt",
     "https://prisma.io/llms-full.txt",
     "https://promptessor.com/llms-full.txt",
+    "https://pubfi.ai/llms-full.txt",
     "https://rainbowkit.com/llms-full.txt",
     "https://raw.githubusercontent.com/raycast/extensions/refs/heads/gh-pages/llms-full.txt",
     "https://resend.com/docs/llms-full.txt",

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -436,6 +436,7 @@
     "https://postfa.st/llms.txt",
     "https://prisma.io/docs/llms.txt",
     "https://prisma.io/llms.txt",
+    "https://pubfi.ai/llms.txt",
     "https://python.langchain.com/llms.txt",
     "https://rainbowkit.com/llms.txt",
     "https://raincamp.ai/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -541,6 +541,8 @@
     "https://prisma.io/docs/llms.txt",
     "https://prisma.io/llms.txt",
     "https://promptessor.com/llms-full.txt",
+    "https://pubfi.ai/llms-full.txt",
+    "https://pubfi.ai/llms.txt",
     "https://python.langchain.com/llms.txt",
     "https://rainbowkit.com/llms-full.txt",
     "https://rainbowkit.com/llms.txt",


### PR DESCRIPTION
Add [https://pubfi.ai/] to the llms.txt list

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

The JSON files are generated automatically after merge.
