### PR TITLE
Add World Cup 2026 Tour llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [aws-legalgroup.com](https://aws-legalgroup.com/llms.txt)
 - [axiom.co (full)](https://axiom.co/docs/llms-full.txt)
 - [axiom.co](https://axiom.co/docs/llms.txt)
+- [ay-worldcup2026.zeabur.app](https://ay-worldcup2026.zeabur.app/llms.txt)
 - [backmesh.com](https://backmesh.com/llms.txt)
 - [bar-sis.com](https://bar-sis.com/llms.txt)
 - [bika.ai](https://bika.ai/llms.txt)

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -19,6 +19,7 @@
     "https://ast-grep.github.io/llms.txt",
     "https://aws-legalgroup.com/llms.txt",
     "https://axiom.co/docs/llms.txt",
+    "https://ay-worldcup2026.zeabur.app/llms.txt",
     "https://backmesh.com/llms.txt",
     "https://bar-sis.com/llms.txt",
     "https://bika.ai/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -22,6 +22,7 @@
     "https://aws-legalgroup.com/llms.txt",
     "https://axiom.co/docs/llms-full.txt",
     "https://axiom.co/docs/llms.txt",
+    "https://ay-worldcup2026.zeabur.app/llms.txt",
     "https://backmesh.com/llms.txt",
     "https://bar-sis.com/llms.txt",
     "https://bika.ai/llms.txt",


### PR DESCRIPTION
Add https://ay-worldcup2026.zeabur.app/llms.txt to the llms.txt index.

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

Validation:

- `python3 scripts/normalize_lists.py --check` passed
- `curl` verified the URL returns HTTP 200 with `text/plain; charset=utf-8`