### PR TITLE
Add Ariadne Loop llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [www.zycus.com](https://www.zycus.com/llms.txt)
 - [wxt.dev](https://wxt.dev/knowledge/docs.txt)
 - [zbrain.ai](https://zbrain.ai/llms.txt)
+- [zhangzeyu99-web.github.io](https://zhangzeyu99-web.github.io/ariadne-loop/llms.txt)
 
 ## Directories
 

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -594,5 +594,6 @@
     "https://www.zenml.io/llms.txt",
     "https://www.zycus.com/llms.txt",
     "https://wxt.dev/knowledge/docs.txt",
-    "https://zbrain.ai/llms.txt"
+    "https://zbrain.ai/llms.txt",
+    "https://zhangzeyu99-web.github.io/ariadne-loop/llms.txt"
 ]

--- a/json/urls.json
+++ b/json/urls.json
@@ -742,5 +742,6 @@
     "https://www.zenml.io/llms.txt",
     "https://www.zycus.com/llms.txt",
     "https://wxt.dev/knowledge/docs.txt",
-    "https://zbrain.ai/llms.txt"
+    "https://zbrain.ai/llms.txt",
+    "https://zhangzeyu99-web.github.io/ariadne-loop/llms.txt"
 ]


### PR DESCRIPTION
Add Ariadne Loop's public llms.txt entry.

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

Validation:

- `python scripts/normalize_lists.py --check`
- `https://zhangzeyu99-web.github.io/ariadne-loop/llms.txt` returns HTTP 200