### PR TITLE
Add InfraNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [iceberg.ma](https://iceberg.ma/llms.txt)
 - [infisical.com (full)](https://infisical.com/docs/llms-full.txt)
 - [infisical.com](https://infisical.com/docs/llms.txt)
+- [infranode.dev](https://infranode.dev/llms.txt)
 - [inter-car.fr](https://inter-car.fr/llms.txt)
 - [iqboatlifts.com (full)](https://iqboatlifts.com/llms-full.txt)
 - [iqboatlifts.com](https://iqboatlifts.com/llms.txt)


### PR DESCRIPTION
Adds infranode.dev to the index (alphabetical order).

llms.txt: https://infranode.dev/llms.txt (returns HTTP 200)

InfraNode is a free unified REST API for German city infrastructure data from 35+ official sources, with documentation in German and English.

Generated with [Claude Code](https://claude.com/claude-code)