### PR TITLE
Add mbtiusa.com llms.txt entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [maplebridge.io](https://maplebridge.io/llms.txt)
 - [martijnvanderdoes.com](https://martijnvanderdoes.com/llms.txt)
 - [mastra.ai](https://mastra.ai/llms.txt)
+- [mbtiusa.com (full)](https://mbtiusa.com/llms-full.txt)
+- [mbtiusa.com](https://mbtiusa.com/llms.txt)
 - [medscanada.com (full)](https://medscanada.com/llms-full.txt)
 - [medscanada.com](https://medscanada.com/llms.txt)
 - [mercedeselizalde.es](https://mercedeselizalde.es/llms.txt)

--- a/json/llms-full.json
+++ b/json/llms-full.json
@@ -91,6 +91,7 @@
     "https://longevityworldcup.com/llms-full.txt",
     "https://loops.so/docs/llms-full.txt",
     "https://manifest.ly/llms-full.txt",
+    "https://mbtiusa.com/llms-full.txt",
     "https://medscanada.com/llms-full.txt",
     "https://mintlify.com/docs/llms-full.txt",
     "https://modelcontextprotocol.io/llms-full.txt",

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -403,6 +403,7 @@
     "https://maplebridge.io/llms.txt",
     "https://martijnvanderdoes.com/llms.txt",
     "https://mastra.ai/llms.txt",
+    "https://mbtiusa.com/llms.txt",
     "https://medscanada.com/llms.txt",
     "https://mercedeselizalde.es/llms.txt",
     "https://mikelev.in/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -495,6 +495,8 @@
     "https://maplebridge.io/llms.txt",
     "https://martijnvanderdoes.com/llms.txt",
     "https://mastra.ai/llms.txt",
+    "https://mbtiusa.com/llms-full.txt",
+    "https://mbtiusa.com/llms.txt",
     "https://medscanada.com/llms-full.txt",
     "https://medscanada.com/llms.txt",
     "https://mercedeselizalde.es/llms.txt",


### PR DESCRIPTION
Add MBTI USA's public AI-readable files to the llms.txt index.

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

Verification:
- `python3 scripts/normalize_lists.py --check`
- `curl -I -L https://mbtiusa.com/llms.txt` returned HTTP 200
- `curl -I -L https://mbtiusa.com/llms-full.txt` returned HTTP 200