### PR TITLE
Add sejemskaoprema.si (llms.txt + llms-full.txt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [screenshotone.com (full)](https://screenshotone.com/docs/llms-full.txt)
 - [screenshotone.com](https://screenshotone.com/docs/llms.txt)
 - [sdk.vercel.ai](https://sdk.vercel.ai/llms.txt)
+- [sejemskaoprema.si (full)](https://sejemskaoprema.si/llms-full.txt)
+- [sejemskaoprema.si](https://sejemskaoprema.si/llms.txt)
 - [semgrep.com (full)](https://semgrep.com/llms-full.txt)
 - [semgrep.com](https://semgrep.com/llms.txt)
 - [semgrep.dev](https://semgrep.dev/llms.txt)

--- a/json/llms-full.json
+++ b/json/llms-full.json
@@ -108,6 +108,7 @@
     "https://raw.githubusercontent.com/raycast/extensions/refs/heads/gh-pages/llms-full.txt",
     "https://resend.com/docs/llms-full.txt",
     "https://screenshotone.com/docs/llms-full.txt",
+    "https://sejemskaoprema.si/llms-full.txt",
     "https://semgrep.com/llms-full.txt",
     "https://signaturegen.app/llms-full.txt",
     "https://smartcar.com/docs/llms-full.txt",

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -449,6 +449,7 @@
     "https://sankeydiagram.net/llms.txt",
     "https://screenshotone.com/docs/llms.txt",
     "https://sdk.vercel.ai/llms.txt",
+    "https://sejemskaoprema.si/llms.txt",
     "https://semgrep.com/llms.txt",
     "https://semgrep.dev/llms.txt",
     "https://seolevante.com/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -558,6 +558,8 @@
     "https://screenshotone.com/docs/llms-full.txt",
     "https://screenshotone.com/docs/llms.txt",
     "https://sdk.vercel.ai/llms.txt",
+    "https://sejemskaoprema.si/llms-full.txt",
+    "https://sejemskaoprema.si/llms.txt",
     "https://semgrep.com/llms-full.txt",
     "https://semgrep.com/llms.txt",
     "https://semgrep.dev/llms.txt",


### PR DESCRIPTION
Adds two entries for sejemskaoprema.si:

- llms.txt — concise root entry
- llms-full.txt — full-text dump of guides + news (sl locale, the site's primary)

About: Slovenian authorized Octanorm distributor for the Adriatic region (SI, HR, RS, BA, ME, MK, AL, XK). Modular trade-fair stand systems, rentals, POS displays. Content in 6 languages (sl/hr/sr/sr-cyrl/en/sq); per-locale llms.txt at /{locale}/llms.txt.

Verified live:
- https://sejemskaoprema.si/llms.txt (HTTP 200)
- https://sejemskaoprema.si/llms-full.txt (HTTP 200, ~340 KB, 32 guides + 50 news posts)

Ran `python3 scripts/normalize_lists.py` after the README edit; all three JSON files updated cleanly.