### PR TITLE
Add Xquik llms.txt entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [www.zenml.io](https://www.zenml.io/llms.txt)
 - [www.zycus.com](https://www.zycus.com/llms.txt)
 - [wxt.dev](https://wxt.dev/knowledge/docs.txt)
+- [xquik.com (full)](https://xquik.com/llms-full.txt)
+- [xquik.com](https://xquik.com/llms.txt)
 - [zbrain.ai](https://zbrain.ai/llms.txt)
 
 ## Directories


### PR DESCRIPTION
## Summary

Adds Xquik's public llms.txt and llms-full.txt links to the README list.

## Checklist

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

## Validation

- Both URLs return 200 with text/plain content.
- README entries are unique.
- Generated JSON files were left unchanged, per the template.
- Git diff check passes.
