### PR TITLE
Add pixelvault.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [orm.drizzle.team](https://orm.drizzle.team/llms.txt)
 - [pandaci.com](https://pandaci.com/llms.txt)
 - [papergraderpro.com](https://papergraderpro.com/llms.txt)
+- [pixelvault.dev](https://pixelvault.dev/llms.txt)
 - [plasticol.es](https://plasticol.es/llms.txt)
 - [pokerreborn.com (full)](https://pokerreborn.com/llms-full.txt)
 - [pokerreborn.com](https://pokerreborn.com/llms.txt)

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -432,6 +432,7 @@
     "https://orm.drizzle.team/llms.txt",
     "https://pandaci.com/llms.txt",
     "https://papergraderpro.com/llms.txt",
+    "https://pixelvault.dev/llms.txt",
     "https://plasticol.es/llms.txt",
     "https://pokerreborn.com/llms.txt",
     "https://postfa.st/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -532,6 +532,7 @@
     "https://orm.drizzle.team/llms.txt",
     "https://pandaci.com/llms.txt",
     "https://papergraderpro.com/llms.txt",
+    "https://pixelvault.dev/llms.txt",
     "https://plasticol.es/llms.txt",
     "https://pokerreborn.com/llms-full.txt",
     "https://pokerreborn.com/llms.txt",


### PR DESCRIPTION
Adds PixelVault's llms.txt — agent-first image hosting on Cloudflare's edge. Inserted alphabetically between papergraderpro.com and plasticol.es.