### PR TITLE
Add crawlgraph.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [console.groq.com](https://console.groq.com/llms.txt)
 - [convex.dev](https://convex.dev/llms.txt)
 - [cookbook_ao.g8way.io](https://cookbook_ao.g8way.io/llms.txt)
+- [crawlgraph.com (full)](https://crawlgraph.com/llms-full.txt)
+- [crawlgraph.com](https://crawlgraph.com/llms.txt)
 - [cv.ryoppippi.com (full)](https://cv.ryoppippi.com/llms-full.txt)
 - [daisyui.com](https://daisyui.com/llms.txt)
 - [daisyui.tailwind.org.cn](https://daisyui.tailwind.org.cn/llms.txt)


### PR DESCRIPTION
Adds crawlgraph.com (both /llms.txt and /llms-full.txt) in alphabetical order. CrawlGraph is a free backlink-intelligence tool on Common Crawl's open hyperlink graph; the llms files cover the product, API, MCP server, and open data studies.