### PR TITLE
Add vibekit.bot to the llms.txt list

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [valdhealth.com](https://valdhealth.com/llms.txt)
 - [vertoai.it (full)](https://vertoai.it/llms-full.txt)
 - [vertoai.it](https://vertoai.it/llms.txt)
+- [vibekit.bot](https://vibekit.bot/llms.txt)
 - [vidovi.ch](https://vidovi.ch/llms.txt)
 - [viem.sh (full)](https://viem.sh/llms-full.txt)
 - [viem.sh](https://viem.sh/llms.txt)


### PR DESCRIPTION
Adds **vibekit.bot** in alphabetical order (between `vertoai.it` and `vidovi.ch`).

VibeKit is a hosted AI app builder — every app gets a persistent AI coding agent that builds, hosts, and keeps improving it, driven from phone / Telegram / CLI. The site serves a maintained `/llms.txt` (also at `/.well-known/llms.txt`).

I can confirm that:

- [x] I added the new link to `README.md`
- [x] The URL points to `llms.txt` (https://vibekit.bot/llms.txt — publicly reachable, 200; no `llms-full.txt`, so only the plain entry)
- [x] The URL is publicly reachable