### PR TITLE
Add app.sfdj.net to llms.txt list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [alphix.com](https://alphix.com/llms.txt)
 - [api-docs.devhub.com](https://api-docs.devhub.com/llms.txt)
 - [apify.com](https://apify.com/llms.txt)
+- [app.sfdj.net](https://app.sfdj.net/llms.txt)
 - [appzung.com](https://appzung.com/llms.txt)
 - [arcadelab.ai](https://arcadelab.ai/llms.txt)
 - [ast-grep.github.io (full)](https://ast-grep.github.io/llms-full.txt)


### PR DESCRIPTION
Add app.sfdj.net to the llms.txt list

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

Verification:

- `curl -L -s -o /tmp/answerlens-llms-check.txt -w '%{http_code} %{content_type} %{url_effective}\n' https://app.sfdj.net/llms.txt`
- Result: `200 text/plain; charset=utf-8 https://app.sfdj.net/llms.txt`
