### PR TITLE
Add getvaletparking.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [galaxy.ai](https://galaxy.ai/llms.txt)
 - [getlago.com (full)](https://getlago.com/docs/llms-full.txt)
 - [getlago.com](https://getlago.com/docs/llms.txt)
+- [getvaletparking.com](https://getvaletparking.com/llms.txt)
 - [github.com](https://github.com/SecretiveShell/MCP-llms-txt)
 - [glaforge.dev (full)](https://glaforge.dev/llms-full.txt)
 - [global-chat.io (full)](https://global-chat.io/llms-full.txt)


### PR DESCRIPTION
Adds getvaletparking.com to the index — national directory of US valet parking operators. llms.txt at https://getvaletparking.com/llms.txt (llmstxt.org format), inserted in alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)