### PR TITLE
Add Tree Ring Memory llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [talkpython.fm](https://talkpython.fm/llms.txt)
 - [tamagui.dev](https://tamagui.dev/llms.txt)
 - [telescope.co](https://telescope.co/llms.txt)
+- [terminallylazy.github.io](https://terminallylazy.github.io/Tree-Ring-Memory/llms.txt)
 - [thataiguy.org](https://thataiguy.org/llms.txt)
 - [thatdeveloperguy.com](https://thatdeveloperguy.com/llms.txt)
 - [thatdevpro.com (full)](https://thatdevpro.com/llms-full.txt)

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -474,6 +474,7 @@
     "https://talkpython.fm/llms.txt",
     "https://tamagui.dev/llms.txt",
     "https://telescope.co/llms.txt",
+    "https://terminallylazy.github.io/Tree-Ring-Memory/llms.txt",
     "https://thataiguy.org/llms.txt",
     "https://thatdeveloperguy.com/llms.txt",
     "https://thatdevpro.com/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -591,6 +591,7 @@
     "https://talkpython.fm/llms.txt",
     "https://tamagui.dev/llms.txt",
     "https://telescope.co/llms.txt",
+    "https://terminallylazy.github.io/Tree-Ring-Memory/llms.txt",
     "https://thataiguy.org/llms.txt",
     "https://thatdeveloperguy.com/llms.txt",
     "https://thatdevpro.com/llms-full.txt",


### PR DESCRIPTION
Add Tree Ring Memory's hosted llms.txt to the index.

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

Validation:

- `python3 scripts/normalize_lists.py --check`
- `python3 scripts/check_urls.py --file <single-url-json> --workers 1 --timeout 20 --follow-redirects`
- `git diff --cached --check`

Note: I included the generated JSON updates because the pull request workflow runs `python scripts/normalize_lists.py --check`.
