### PR TITLE
Add citeable.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [cichpack.com](https://cichpack.com/llms.txt)
 - [citability.ai (full)](https://citability.ai/llms-full.txt)
 - [citability.ai](https://citability.ai/llms.txt)
+- [citeable.eu (full)](https://citeable.eu/llms-full.txt)
+- [citeable.eu](https://citeable.eu/llms.txt)
 - [cleverhack.com](https://cleverhack.com/llms.txt)
 - [cloud.needle.tools (full)](https://cloud.needle.tools/llms-full.txt)
 - [cloud.needle.tools](https://cloud.needle.tools/llms.txt)


### PR DESCRIPTION
Adds citeable.eu (llms.txt + llms-full.txt) to the index — a live llms.txt hosted on the site, placed alphabetically between citability.ai and cleverhack.com.