### PR TITLE
Add smry.ai llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [sitespeak.ai](https://sitespeak.ai/llms.txt)
 - [smartcar.com (full)](https://smartcar.com/docs/llms-full.txt)
 - [smartcar.com](https://smartcar.com/docs/llms.txt)
+- [smry.ai (full)](https://smry.ai/llms-full.txt)
+- [smry.ai](https://smry.ai/llms.txt)
 - [solt.app](https://solt.app/llms.txt)
 - [sourcegraph.com](https://sourcegraph.com/docs/llms.txt)
 - [sprytools.com](https://sprytools.com/llms.txt)

--- a/json/llms-full.json
+++ b/json/llms-full.json
@@ -113,6 +113,7 @@
     "https://semgrep.com/llms-full.txt",
     "https://signaturegen.app/llms-full.txt",
     "https://smartcar.com/docs/llms-full.txt",
+    "https://smry.ai/llms-full.txt",
     "https://starwind.dev/llms-full.txt",
     "https://svelte.dev/llms-full.txt",
     "https://svelte.nodejs.cn/llms-full.txt",

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -462,6 +462,7 @@
     "https://siteria.by/llms.txt",
     "https://sitespeak.ai/llms.txt",
     "https://smartcar.com/docs/llms.txt",
+    "https://smry.ai/llms.txt",
     "https://solt.app/llms.txt",
     "https://sourcegraph.com/docs/llms.txt",
     "https://sprytools.com/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -576,6 +576,8 @@
     "https://sitespeak.ai/llms.txt",
     "https://smartcar.com/docs/llms-full.txt",
     "https://smartcar.com/docs/llms.txt",
+    "https://smry.ai/llms-full.txt",
+    "https://smry.ai/llms.txt",
     "https://solt.app/llms.txt",
     "https://sourcegraph.com/docs/llms.txt",
     "https://sprytools.com/llms.txt",


### PR DESCRIPTION
Add smry.ai to the llms.txt list.

I can confirm that:

- [x] I added the new links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

The JSON files were regenerated with the repository's normalization script.

## Validation

- `python3 scripts/normalize_lists.py --check`
- `python3 scripts/check_urls.py --file /tmp/smry-urls.json --workers 2 --timeout 20` — 2 URLs checked, 2 OK
- `git diff --check`

Contact: contact@smry.ai
