### PR TITLE
Add techpotions.com to the llms.txt list

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [svelte.nodejs.cn (full)](https://svelte.nodejs.cn/llms-full.txt)
 - [talkpython.fm](https://talkpython.fm/llms.txt)
 - [tamagui.dev](https://tamagui.dev/llms.txt)
+- [techpotions.com](https://techpotions.com/llms.txt)
 - [telescope.co](https://telescope.co/llms.txt)
 - [thataiguy.org](https://thataiguy.org/llms.txt)
 - [thatdeveloperguy.com](https://thatdeveloperguy.com/llms.txt)


### PR DESCRIPTION
Add [techpotions.com](https://techpotions.com/llms.txt) to the llms.txt list

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable (200, ~16 KB)