### PR TITLE
Add hellomatik.com to the llms.txt index

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [handbook.exemplar.dev (full)](https://handbook.exemplar.dev/llms-full.txt)
 - [handbook.exemplar.dev](https://handbook.exemplar.dev/llms.txt)
 - [handledtax.com](https://handledtax.com/llms.txt)
+- [hellomatik.com](https://hellomatik.com/llms.txt)
 - [herd.garden (full)](https://herd.garden/llms-full.txt)
 - [herd.garden](https://herd.garden/llms.txt)
 - [heritagehardwoodfloors.thatwebhostingguy.com](https://heritagehardwoodfloors.thatwebhostingguy.com/llms.txt)


### PR DESCRIPTION
Adds **hellomatik.com** to the index, in alphabetical order (between handledtax.com and herd.garden). Hellomatik publishes a well-formed llms.txt at https://hellomatik.com/llms.txt describing its AI agent platform (customer service, sales and internal operations across web chat, WhatsApp and voice). Single-line addition. Thanks for maintaining this index!