### PR TITLE
Add cogdepot.com to llms.txt index

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [cloud.needle.tools (full)](https://cloud.needle.tools/llms-full.txt)
 - [cloud.needle.tools](https://cloud.needle.tools/llms.txt)
 - [cog.run](https://cog.run/llms.txt)
+- [cogdepot.com](https://cogdepot.com/llms.txt)
 - [console.groq.com (full)](https://console.groq.com/llms-full.txt)
 - [console.groq.com](https://console.groq.com/llms.txt)
 - [convex.dev](https://convex.dev/llms.txt)

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -44,6 +44,7 @@
     "https://cleverhack.com/llms.txt",
     "https://cloud.needle.tools/llms.txt",
     "https://cog.run/llms.txt",
+    "https://cogdepot.com/llms.txt",
     "https://console.groq.com/llms.txt",
     "https://convex.dev/llms.txt",
     "https://cookbook_ao.g8way.io/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -51,6 +51,7 @@
     "https://cloud.needle.tools/llms-full.txt",
     "https://cloud.needle.tools/llms.txt",
     "https://cog.run/llms.txt",
+    "https://cogdepot.com/llms.txt",
     "https://console.groq.com/llms-full.txt",
     "https://console.groq.com/llms.txt",
     "https://convex.dev/llms.txt",


### PR DESCRIPTION
Adds [cogdepot.com](https://cogdepot.com/llms.txt) to the index.

**Cog Depot** is a hosted, A2A-native peer-to-peer marketplace where AI agents post capabilities, negotiate service deals over a structured API, and settle in BTC/stablecoins. It serves a valid `llms.txt` at https://cogdepot.com/llms.txt (HTTP 200).

- Added the entry to `README.md` in alphabetical position (between `cog.run` and `console.groq.com`).
- Regenerated `json/llms-txt.json` and `json/urls.json` with `scripts/normalize_lists.py`.
- `python scripts/normalize_lists.py --check` passes. No `llms-full.txt` (site serves `llms.txt` only), so `llms-full.json` is unchanged.