### PR TITLE
add openchainbench.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [onevcat.com](https://onevcat.com/llms.txt)
 - [open.longportapp.com](https://open.longportapp.com/llms.txt)
 - [openalternative.co](https://openalternative.co/llms.txt)
+- [openchainbench.com (full)](https://openchainbench.com/llms-full.txt)
+- [openchainbench.com](https://openchainbench.com/llms.txt)
 - [openrouter.ai (full)](https://openrouter.ai/docs/llms-full.txt)
 - [openrouter.ai](https://openrouter.ai/docs/llms.txt)
 - [orm.drizzle.team (full)](https://orm.drizzle.team/llms-full.txt)


### PR DESCRIPTION
OpenChainBench publishes both llms.txt and llms-full.txt per the llmstxt.org spec. It's an open benchmark platform for crypto infrastructure (94 live benches, CC-BY-4.0 data). https://openchainbench.com/llms.txt