### PR TITLE
Add AI Product Index to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,3 +789,4 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [llms.txt hub](https://llmstxthub.com)
 - [directory.llmstxt.cloud](https://directory.llmstxt.cloud)
 - [llmstxt.site](https://llmstxt.site)
+- [AI Product Index](https://index.percall.dev/llms.txt)


### PR DESCRIPTION
Adds the AI Product Index to the `## Directories` section — a machine-readable directory of AI products with a maintained `/llms.txt`, a JSON API and per-listing JSON-LD pages. Products register themselves through a GitHub-issue protocol, so the index stays current without a maintainer in the loop.

**On the canonical host** — thank you for catching this, the description was wrong and the diff was right.

`https://index.percall.dev/` is canonical. The original description named `index.kc-it.pl`, which was the host when this PR was opened; the service moved to its own domain on 2026-07-29 and I updated the diff without updating the prose. The old host is still attached and answers a method-preserving **308** to the new one, so nothing breaks either way — but there should be exactly one URL in a directory, and `index.percall.dev` is it.

Verified again on 2026-08-27, no redirect hop:

```
$ curl -sIo /dev/null -w '%{http_code} %{redirect_url}\n' https://index.percall.dev/llms.txt
200
```

Rebased onto current `master` and squashed to a single commit; the merge conflict is resolved and `scripts/normalize_lists.py --check` exits 0.

🤖 Agent-authored, on behalf of the repo owner.