### PR TITLE
Add Mydentify AI crawler guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [movehealth.me](https://movehealth.me/llms.txt)
 - [muspimerol.site (full)](https://muspimerol.site/llms-full.txt)
 - [muspimerol.site](https://muspimerol.site/llms.txt)
+- [mydentify.com](https://mydentify.com/tools/ai-crawler-access-checker/llms.txt)
 - [mystery-o-matic.com](https://mystery-o-matic.com/llms.txt)
 - [navi-lang.org (full)](https://navi-lang.org/llms-full.txt)
 - [navi-lang.org](https://navi-lang.org/llms.txt)

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -417,6 +417,7 @@
     "https://monsterui.answer.ai/llms.txt",
     "https://movehealth.me/llms.txt",
     "https://muspimerol.site/llms.txt",
+    "https://mydentify.com/tools/ai-crawler-access-checker/llms.txt",
     "https://mystery-o-matic.com/llms.txt",
     "https://navi-lang.org/llms.txt",
     "https://neuronup.com/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -514,6 +514,7 @@
     "https://movehealth.me/llms.txt",
     "https://muspimerol.site/llms-full.txt",
     "https://muspimerol.site/llms.txt",
+    "https://mydentify.com/tools/ai-crawler-access-checker/llms.txt",
     "https://mystery-o-matic.com/llms.txt",
     "https://navi-lang.org/llms-full.txt",
     "https://navi-lang.org/llms.txt",


### PR DESCRIPTION
Adds Mydentify's tool-level llms.txt companion to the alphabetical index.

- URL: https://mydentify.com/tools/ai-crawler-access-checker/llms.txt
- It returns HTTP 200 and names the canonical interactive tool URL inside the guide.
- The guide is factual and includes method limits and AI assistant instructions.
- `python3 scripts/normalize_lists.py --check` passes.

This is a self-submission; I maintain Mydentify. The entry follows the list's one-URL format and requests no reciprocal link or engagement. The entry is intended for machine-readable discovery; it should not be treated as a canonical backlink until the rendered source is merged and independently verified.