### PR TITLE
Add llms-txt-validator.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [llm.rememberizer.ai (full)](https://llm.rememberizer.ai/llms-full.txt)
 - [llm.skydeck.ai (full)](https://llm.skydeck.ai/llms-full.txt)
 - [llm.skydeck.ai](https://llm.skydeck.ai/llms.txt)
+- [llms-txt-validator.dev (full)](https://llms-txt-validator.dev/llms-full.txt)
+- [llms-txt-validator.dev](https://llms-txt-validator.dev/llms.txt)
 - [llmstxt.org](https://llmstxt.org/llms.txt)
 - [llmstxtmanager.com](https://llmstxtmanager.com/llms.txt)
 - [lmstudio.ai (full)](https://lmstudio.ai/llms-full.txt)


### PR DESCRIPTION
Adds llms-txt-validator.dev (a free llms.txt validator that fetches every linked URL and scores the file). Both llms.txt and llms-full.txt are served (HTTP 200), inserted alphabetically in the L section.