### PR TITLE
Add aura-ui.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [arcadelab.ai](https://arcadelab.ai/llms.txt)
 - [ast-grep.github.io (full)](https://ast-grep.github.io/llms-full.txt)
 - [ast-grep.github.io](https://ast-grep.github.io/llms.txt)
+- [aura-ui.com (full)](https://aura-ui.com/llms-full.txt)
+- [aura-ui.com](https://aura-ui.com/llms.txt)
 - [aws-legalgroup.com](https://aws-legalgroup.com/llms.txt)
 - [axiom.co (full)](https://axiom.co/docs/llms-full.txt)
 - [axiom.co](https://axiom.co/docs/llms.txt)


### PR DESCRIPTION
Add aura-ui.com to the llms.txt list

I can confirm that:

- [X] I added the new link or links to `README.md`
- [X] Each URL points to `llms.txt` or `llms-full.txt`
- [X] Each URL is publicly reachable

The JSON files are generated automatically after merge.
