### PR TITLE
Add engagemii.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [elevenlabs.io (full)](https://elevenlabs.io/docs/llms-full.txt)
 - [elevenlabs.io](https://elevenlabs.io/docs/llms.txt)
 - [emailgic.com](https://emailgic.com/llms.txt)
+- [engagemii.com](https://engagemii.com/llms.txt)
 - [erdaltoprak.com](https://erdaltoprak.com/llms.txt)
 - [evacalendar.app (full)](https://evacalendar.app/llms-full.txt)
 - [evacalendar.app](https://evacalendar.app/llms.txt)


### PR DESCRIPTION
Adds `engagemii.com` to the list, inserted alphabetically between emailgic.com and erdaltoprak.com.

- [x] Added a link to `README.md`
- [x] The URL points to an `llms.txt` file: https://engagemii.com/llms.txt
- [x] The URL is publicly reachable (HTTP 200, no auth)

`llms-full.txt` does not exist for this domain, so only the one line is added. I did not touch `json/`.

Disclosure: I work on Engagemii.