### PR TITLE
Add dinnerelite.com to the llms.txt list

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [developers.portone.io](https://developers.portone.io/llms.txt)
 - [developers.raycast.com](https://developers.raycast.com/llms.txt)
 - [developers.sitecore.com](https://developers.sitecore.com/llms.txt)
+- [dinnerelite.com (full)](https://dinnerelite.com/llms-full.txt)
+- [dinnerelite.com](https://dinnerelite.com/llms.txt)
 - [directory.llmstxt.cloud](https://directory.llmstxt.cloud/llms.txt)
 - [dnacore.ai](https://dnacore.ai/llms.txt)
 - [docs-en.sinch.com](https://docs-en.sinch.com/llms.txt)


### PR DESCRIPTION
Add [dinnerelite.com] to the llms.txt list

I can confirm that:

- [x] I added the new link or links to `README.md`
- [x] Each URL points to `llms.txt` or `llms-full.txt`
- [x] Each URL is publicly reachable

Two entries, inserted in alphabetical order between `developers.sitecore.com` and `directory.llmstxt.cloud`, with the `(full)` variant first to match the convention used by `agentgrade.com`, `dejanmarkovic.com` and others:

- `https://dinnerelite.com/llms-full.txt` — 773 KB
- `https://dinnerelite.com/llms.txt` — 27 KB

Both verified `200` today. Only `README.md` is touched, since the PR template notes the JSON files are generated after merge.

DinnerElite is a reservation-alert service for hard-to-book New York restaurants. Beyond the two files above, every page is also published as a markdown twin at the same path plus `.md` (363 of them), indexed at https://dinnerelite.com/sitemap-md.xml and declared in `robots.txt`.