### PR TITLE
Add universalcommerceprotocol.blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [turva.dev (full)](https://turva.dev/llms-full.txt)
 - [turva.dev](https://turva.dev/llms.txt)
 - [twittershots.com (full)](https://twittershots.com/llms-full.txt)
+- [universalcommerceprotocol.blog](https://universalcommerceprotocol.blog/llms.txt)
 - [unlocksaas.com (full)](https://unlocksaas.com/llms-full.txt)
 - [unlocksaas.com](https://unlocksaas.com/llms.txt)
 - [upcgen.com (full)](https://upcgen.com/llms-full.txt)

--- a/json/llms-txt.json
+++ b/json/llms-txt.json
@@ -505,6 +505,7 @@
     "https://trigger.dev/docs/llms.txt",
     "https://turbo.build/llms.txt",
     "https://turva.dev/llms.txt",
+    "https://universalcommerceprotocol.blog/llms.txt",
     "https://unlocksaas.com/llms.txt",
     "https://upcgen.com/llms.txt",
     "https://upstash.com/docs/llms.txt",

--- a/json/urls.json
+++ b/json/urls.json
@@ -635,6 +635,7 @@
     "https://turva.dev/llms-full.txt",
     "https://turva.dev/llms.txt",
     "https://twittershots.com/llms-full.txt",
+    "https://universalcommerceprotocol.blog/llms.txt",
     "https://unlocksaas.com/llms-full.txt",
     "https://unlocksaas.com/llms.txt",
     "https://upcgen.com/llms-full.txt",


### PR DESCRIPTION
Adds `https://universalcommerceprotocol.blog/llms.txt`, an independent editorial site covering the Universal Commerce Protocol and agentic commerce.

- Single canonical `llms.txt` entry. The non-standard `llms-en.txt` entry from #34 has been removed.
- No `llms-full.txt` is published on that domain, so no `(full)` entry is included.
- Rebased on the current `master`, so no conflicts.
- Generated lists regenerated with `scripts/normalize_lists.py`, so `json/llms-txt.json` and `json/urls.json` stay in sync.

Supersedes #34.