### PR TITLE
Add farrelldan.github.io/ai-bot-directory llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ This list contains an index of llms.txt files hosted on various websites. Attach
 - [examace.ca (full)](https://examace.ca/llms-full.txt)
 - [examace.ca](https://examace.ca/llms.txt)
 - [faq.karrier.one](https://faq.karrier.one/llms.txt)
+- [farrelldan.github.io/ai-bot-directory](https://farrelldan.github.io/ai-bot-directory/llms.txt)
 - [fastcrw.com](https://fastcrw.com/llms.txt)
 - [fasttool.app](https://fasttool.app/llms.txt)
 - [feedthejoe.com](https://feedthejoe.com/llms.txt)


### PR DESCRIPTION
Adds the llms.txt for Bot Ledger, a free directory of verified AI/LLM crawlers plus a robots.txt / llms.txt generator (https://farrelldan.github.io/ai-bot-directory/). Site publishes its own llms.txt at the linked URL.